### PR TITLE
Add templateExtensions setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ You can create as many templates as you need. It's also possible to create multi
 separated templatePath can be used if there are multiple folders with templates). 
 You can for example create a template folder per project so it can be shared with other project members together with the rest of the code.
 
+**template extensions**
+
+If a filename of your template files has one of the extensions from the `templateExtensions` setting, this extension
+will be stripped from the generated filenames. Templates with other extensions will keep the same extension.
+
+The default value for the `templateExtensions` setting is `[".sg"]`. This means that, for example, a template named
+`foo.txt.sg` will generate a file with the filename `foo.txt`. 
+
 #### Variables
 
 Templates can be customized by using variables. Variables can be used as folder name in the following format ```{variable}```. 
@@ -191,6 +199,8 @@ Options:
 
 * ```-d, --destination <destination>```: Override the destination for store module.
 * ```-p, --template-path <template-path>```: Override template path.
+* ```-e, --template-extensions <extensions>```: Override the template extensions by providing a comma-separated list of 
+template extensions. 
 * ```-s, --sub-directory <subdirectory>```: Set subdirectory. This path is added to the destination path. 
 * ```-f, --force```: Force creation. By default it's impossible to create code if the destination path doesn't exist 
 or when the files already exists in the destination path. This option forces the creation of code and will generates the destination folders if they don't exist. 
@@ -221,6 +231,7 @@ Options:
 
 * ```-d, --destination <destination>```: Set the destination path.
 * ```-t, --template-path <template-path>```: Set template path.
+* ```-e, --template-extensions <extensions>```: Set template extensions (provide a comma-separated list).
 * ```-l, --log```: Log global or local settings depending on the global flag.
 * ```-g, --global```: Set global settings.
 

--- a/bin/seng-generator-generate
+++ b/bin/seng-generator-generate
@@ -23,6 +23,7 @@ program
 	.option('-d, --destination <destination>', 'Override destination')
 	.option('-s, --sub-directory <directory>', 'Set subdirectory')
 	.option('-p, --template-path <template-path>', 'Override template path')
+	.option('-e, --template-extensions <extensions>', 'Comma-separated list of template extensions')
 	.option('-f, --force', 'Force creation of a component')
 	.option('-v, --variables <variables>', 'Set custom variables')
 	.option('-w, --wizard', 'Use wizard to set custom variables')
@@ -50,6 +51,10 @@ if (program.subDirectory) {
 
 if (program.templatePath) {
 	settingsOverrides['templatePath'] = program.templatePath;
+}
+
+if (program.templateExtensions) {
+	settingsOverrides['templateExtensions'] = program.templateExtensions.split(',');
 }
 
 const settings = Settings.getSettings(settingsOverrides);

--- a/bin/seng-generator-settings
+++ b/bin/seng-generator-settings
@@ -7,6 +7,7 @@ const Settings = require('../src/settings');
 program
 	.option('-d, --destination <destination>', 'Set default destination')
 	.option('-t, --template-path <destination>', 'Set default template directory')
+	.option('-e, --template-extensions <extensions>', 'Comma-separated list of template extensions')
 	.option('-g, --global', 'Set global settings')
 	.option('-l, --log', 'Log global or local settings depending on global flag')
 	.parse(process.argv);
@@ -34,6 +35,10 @@ if (program.destination) {
 
 if (program.templatePath) {
 	settings['templatePath'] = program.templatePath;
+}
+
+if (program.templateExtensions) {
+	settings['templateExtensions'] = program.templateExtensions.split(',');
 }
 
 if (Object.keys(settings).length == 0 && !program.global) {

--- a/src/generate.js
+++ b/src/generate.js
@@ -39,6 +39,7 @@ module.exports = function generate(type, options, settings) {
 			.clean(false)
 			.use(filterSettings)
 			.use(renderPaths)
+			.use(removeTemplateExtensions(settings))
 			.use(renderTemplates)
 			.use(!options.force ? checkExists : (files, metalsmith, done) => done())
 			.build((err) => {
@@ -81,6 +82,28 @@ function renderPaths(files, metalsmith, done) {
 	});
 
 	done();
+}
+
+function removeTemplateExtensions(settings) {
+	return function removeTemplateExtensionsPlugin(files, metalsmith, done) {
+		const keys = Object.keys(files);
+
+		keys.forEach((key) => {
+			let newKey = settings.templateExtensions.reduce((currentFilename, extension) => {
+				if (currentFilename.endsWith(extension)) {
+					return currentFilename.substring(0, currentFilename.length - extension.length);
+				}
+				return currentFilename;
+			}, key);
+
+			if (newKey != key) {
+				files[newKey] = files[key];
+				delete files[key];
+			}
+		});
+
+		done();
+	}
 }
 
 function filterSettings(files, metalsmith, done) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -8,7 +8,8 @@ const _ = require('lodash');
 
 const defaultSettings = {
 	templatePath: '',
-	destination: '.'
+	destination: '.',
+	templateExtensions: ['.sg']
 };
 
 exports.getSettings = function (overrides = {}, ignoreLocalSettings = false, ignoreTemplateSettings = false) {


### PR DESCRIPTION
Create a templateExtensions setting. File extensions in this setting will be stripped from final output. This is useful if you want your template filenames to have different file extensions so they are not picked up by the same tooling.